### PR TITLE
fix: Delete shebang regex and add `.vsh` extenstion

### DIFF
--- a/languages/v/config.toml
+++ b/languages/v/config.toml
@@ -1,7 +1,7 @@
 name = "V"
 grammar = "v"
-path_suffixes = ["v", "vv", "mod"]
-first_line_pattern = '^#![^\\n]+'
+path_suffixes = ["v", "vv", "vsh", "mod"]
+first_line_pattern = "^#!.*/(?:v|env(?: .*)? v)(?: |$)"
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
Please see zed-industries/zed#23751 and the [docs](https://docs.vlang.io/other-v-features.html#vsh-scripts-with-no-extension).

Now you open `*.vsh` and get valid language selection, but it's up to the user to provide a proper shebang.